### PR TITLE
Enhancements to directory handling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 =======
 History
 =======
+2024.8.23 -- Enhancements to directory handling
+  * Changed the handling of paths to make them relative to the directory that the step
+    is running in. In a loop, for instance, files are relative to the iteration
+    directory.
+  * When reading files, allow the syntax 'job://<job number>/...' to read files from
+    another job. If the job number is omitted, so the prefix is 'job:///...', the top
+    directory of the current job is used.
+
 2024.7.28 -- Added new names for systems and configurations
   * Made the naming of systems and configurations consistent with the standard
     parameters for them in the GUI.

--- a/read_structure_step/write_structure.py
+++ b/read_structure_step/write_structure.py
@@ -12,7 +12,7 @@ directory, and is used for all normal output from this step.
 """
 
 import logging
-from pathlib import PurePath
+from pathlib import Path
 import textwrap
 
 import read_structure_step
@@ -159,9 +159,15 @@ class WriteStructure(seamm.Node):
             context=seamm.flowchart_variables._data
         )
 
+        # Save relative to current working directory
+        wd = Path(self.directory).parent
+
         # What type of file?
         filename = P["file"].strip()
-        path = PurePath(filename)
+        if filename.startswith("/"):
+            path = Path(self.flowchart.root_directory) / filename[1:]
+        else:
+            path = wd / filename
         file_type = P["file type"]
 
         if file_type != "from extension":
@@ -223,7 +229,7 @@ class WriteStructure(seamm.Node):
             )
         if n_per_file == "all" or n_configurations <= n_per_file:
             write(
-                filename,
+                str(path),
                 configurations,
                 extension=extension,
                 remove_hydrogens=P["remove hydrogens"],


### PR DESCRIPTION
* Changed the handling of paths to make them relative to the directory that the step is running in. In a loop, for instance, files are relative to the iteration directory.
* When reading files, allow the syntax 'job://<job number>/...' to read files from another job. If the job number is omitted, so the prefix is 'job:///...', the top directory of the current job is used.