### PR TITLE
Bugfix: MOPAC files with references in comments

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2024.11.3 -- Bugfix: MOPAC files with references in comments
+  * Fixed a bug that caused a crash when reading MOPAC files with references in the
+    comments.
+  * Updated the MOPAC reader to the new approach for running MOPAC in the cases that
+    it is needed: Z-matrices and mixed inputs that OpenBabel can't handle.
+      
 2024.8.23 -- Enhancements to directory handling
   * Changed the handling of paths to make them relative to the directory that the step
     is running in. In a loop, for instance, files are relative to the iteration

--- a/read_structure_step/formats/mop/find_mopac.py
+++ b/read_structure_step/formats/mop/find_mopac.py
@@ -1,6 +1,7 @@
-import seamm_util
 from pathlib import Path
 import os
+
+import seamm_util
 
 mopac_error_identifiers = []
 

--- a/read_structure_step/read.py
+++ b/read_structure_step/read.py
@@ -21,6 +21,7 @@ def read(
     printer=None,
     references=None,
     bibliography=None,
+    step=None,
 ):
     """
     Calls the appropriate functions to parse the requested file.
@@ -69,6 +70,9 @@ def read(
 
     bibliography : dict
         The bibliography as a dictionary.
+
+    step : seamm.Node = None
+        The node in the flowchart, used for running e.g. MOPAC.
 
     Returns
     -------
@@ -124,6 +128,7 @@ def read(
         printer=printer,
         references=references,
         bibliography=bibliography,
+        step=step,
     )
 
     return configurations


### PR DESCRIPTION
  
* Fixed a bug that caused a crash when reading MOPAC files with references in the comments.
* Updated the MOPAC reader to the new approach for running MOPAC in the cases that it is needed: Z-matrices and mixed inputs that OpenBabel can't handle.