### PR TITLE
Enhancements to SDF and XYZ files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 =======
 History
 =======
+2025.1.3 -- Enhancements to SDF and XYZ files
+  * Added more keywords to the header of XYZ files to allow for more flexibility in
+    reading them. Specifically 'title', 'model', and 'name', which can be used to name
+    the system and/or configuration.
+  * When reading SDF files, 'keep current name' will use the encoded system name in SDF
+    files written by SEAMM, if it exists.
+  * Fixed minor issue writing SDF files where the 'configurations' widget was displayed
+    when writing the current configuration. The widget is now correctly hidden.
+    
 2024.12.29 -- Bugfix: Issue with reusing systems matching SDF files.
   * The logic was faulty, so if the first structure in an SDF file was a configuration
     of an existing system, it was not added to the system correctly.

--- a/read_structure_step/formats/sdf/sdf.py
+++ b/read_structure_step/formats/sdf/sdf.py
@@ -9,6 +9,7 @@ import shutil
 import string
 import subprocess
 import time
+import traceback
 
 from openbabel import openbabel
 
@@ -209,7 +210,7 @@ def load_sdf(
             # See if either the system or configuration names are "title"
             if (
                 system_name is not None
-                and system_name.lower() == "title"
+                and system_name.lower() in ("keep current name", "title")
                 and have_sysname
             ):
                 # Reuse the system if it exists
@@ -217,7 +218,7 @@ def load_sdf(
                     system = system_db.get_system(sysname)
                 elif structure_no > 1:
                     system = system_db.create_system()
-                if configuration_name.lower() == "title":
+                if configuration_name.lower() in ("keep current name", "title"):
                     names = system.configuration_names
                     if confname in names:
                         cid = system.get_configuration_id(confname)
@@ -238,6 +239,9 @@ def load_sdf(
                 printer("")
                 printer(f"    Error handling entry {record_no} in the SDF file:")
                 printer("        " + str(e))
+                printer(60 * "-")
+                printer("\n".join(traceback.format_exception(e)))
+                printer(60 * "-")
                 printer("    Text of the entry is")
                 printer("    " + 60 * "-")
                 for line in text.splitlines():
@@ -253,7 +257,7 @@ def load_sdf(
             # Set the system name
             if system_name is not None and system_name != "":
                 lower_name = system_name.lower()
-                if lower_name == "title":
+                if lower_name in ("keep current name", "title"):
                     if sysname != "":
                         system.name = sysname
                     else:
@@ -276,7 +280,7 @@ def load_sdf(
             # And the configuration name
             if configuration_name is not None and configuration_name != "":
                 lower_name = configuration_name.lower()
-                if lower_name == "title":
+                if lower_name in ("keep current name", "title"):
                     if confname != "":
                         configuration.name = confname
                     else:

--- a/read_structure_step/formats/xyz/xyz.py
+++ b/read_structure_step/formats/xyz/xyz.py
@@ -393,6 +393,9 @@ def load_xyz(
                     ):
                         logger.warning(f"{structure_no}: {tmp}")
 
+                # Extract any additional information from the title
+                extra = {}
+
                 if file_type == "Minnesota":
                     # Record the charge, and the spin state
                     configuration.charge = charge
@@ -415,8 +418,17 @@ def load_xyz(
                                     configuration.spin_multiplicity = int(val)
                                 except Exception:
                                     pass
-                            elif key == "CSD_code":
+                            elif key in ("CSD_code", "title"):
                                 title = val
+                            elif key == "model":
+                                extra["model"] = val
+                            elif key == "name":
+                                extra["name"] = val
+                            elif key == "symmetry":
+                                extra["symmetry"] = val
+                        else:
+                            if tmp == "TS":
+                                extra["target"] = "TS"
 
                 # Set the system name
                 if system_name is not None and system_name != "":
@@ -438,6 +450,10 @@ def load_xyz(
                         system.name = configuration.inchi
                     elif "formula" in lower_name:
                         system.name = configuration.formula[0]
+                    elif "name" in lower_name and "name" in extra:
+                        system.name = extra["name"]
+                    elif "model" in lower_name and "model" in extra:
+                        system.name = extra["model"]
                     else:
                         system.name = system_name
 
@@ -463,6 +479,10 @@ def load_xyz(
                         configuration.name = str(structure_no)
                     elif "formula" in lower_name:
                         configuration.name = configuration.formula[0]
+                    elif "name" in lower_name and "name" in extra:
+                        configuration.name = extra["name"]
+                    elif "model" in lower_name and "model" in extra:
+                        configuration.name = extra["model"]
                     else:
                         configuration.name = configuration_name
 

--- a/read_structure_step/tk_write_structure.py
+++ b/read_structure_step/tk_write_structure.py
@@ -46,7 +46,7 @@ class TkWriteStructure(seamm.TkNode):
             self[key] = P[key].widget(frame)
 
         # Set bindings
-        for name in ("file", "file type"):
+        for name in ("file", "file type", "structures"):
             combobox = self[name].combobox
             combobox.bind("<<ComboboxSelected>>", self.reset_dialog)
             combobox.bind("<Return>", self.reset_dialog)
@@ -72,6 +72,7 @@ class TkWriteStructure(seamm.TkNode):
         extension = ""
         filename = self["file"].get().strip()
         file_type = self["file type"].get()
+        structures = self["structures"].get()
 
         if self.is_expr(filename) or self.is_expr(file_type):
             extension = "all"
@@ -100,7 +101,8 @@ class TkWriteStructure(seamm.TkNode):
         items = []
         if extension == "all" or not metadata["single_structure"]:
             items.append("structures")
-            items.append("configurations")
+            if structures != "current configuration":
+                items.append("configurations")
             items.append("ignore missing")
             items.append("number per file")
         items.append("remove hydrogens")


### PR DESCRIPTION
* Added more keywords to the header of XYZ files to allow for more flexibility in reading them. Specifically 'title', 'model', and 'name', which can be used to name the system and/or configuration.
* When reading SDF files, 'keep current name' will use the encoded system name in SDF files written by SEAMM, if it exists.
* Fixed minor issue writing SDF files where the 'configurations' widget was displayed when writing the current configuration. The widget is now correctly hidden.