### PR TITLE
Bugfix: Issue with reading XYZ files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2025.1.3.1 -- Bugfix: Issue with reading XYZ files
+  * If the XYZ file had the charge and spin multiplicity encoded in the comment line,
+    and the spin multiplicity came before the charge, the spin multiplicity was not
+    correctly set. This fixes that issue.
+    
 2025.1.3 -- Enhancements to SDF and XYZ files
   * Added more keywords to the header of XYZ files to allow for more flexibility in
     reading them. Specifically 'title', 'model', and 'name', which can be used to name

--- a/read_structure_step/formats/xyz/xyz.py
+++ b/read_structure_step/formats/xyz/xyz.py
@@ -403,6 +403,9 @@ def load_xyz(
 
                     logger.info(f"{charge=} {multiplicity=}")
                 elif "|" in title:
+                    # Careful! Setting charge sets spin to 0, so remember if we set
+                    # spin first
+                    spin = None
                     for tmp in title.split("|"):
                         if "=" in tmp:
                             key, val = tmp.split("=", maxsplit=1)
@@ -410,12 +413,15 @@ def load_xyz(
                             val = val.strip()
                             if key == "q":
                                 try:
-                                    configuration.charge = float(val)
+                                    configuration.charge = int(val)
+                                    if spin is not None:
+                                        configuration.spin_multiplicity = spin
                                 except Exception:
                                     pass
                             elif key == "S":
                                 try:
-                                    configuration.spin_multiplicity = int(val)
+                                    spin = int(val)
+                                    configuration.spin_multiplicity = spin
                                 except Exception:
                                     pass
                             elif key in ("CSD_code", "title"):


### PR DESCRIPTION
  
* If the XYZ file had the charge and spin multiplicity encoded in the comment line, and the spin multiplicity came before the charge, the spin multiplicity was not correctly set. This fixes that issue.