### PR TITLE
Improved handling of system names in SDF files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2025.3.4 -- Improved handling of system names in SDF files
+  * Switched to new handling of system and configuration names as properties in SDF
+    files, rather than encoded in the title. This avoids problems with special
+    characters in name, for example when using SMILES as the name.
+    
 2025.1.15 -- Added ability to write using an arbitrary list of structures.
 
 2025.1.3.1 -- Bugfix: Issue with reading XYZ files

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pip
 
   # SEAMM
+  - libsqlite!=3.49.1
   - seamm
 
   # Testing

--- a/read_structure_step/formats/openbabel_io/obabel.py
+++ b/read_structure_step/formats/openbabel_io/obabel.py
@@ -1,5 +1,4 @@
-"""Implementation of the chemical file reader/write using Open Babel
-"""
+"""Implementation of the chemical file reader/write using Open Babel"""
 
 from pathlib import Path
 import shutil


### PR DESCRIPTION
* Switched to new handling of system and configuration names as properties in SDF files, rather than encoded in the title. This avoids problems with special characters in name, for example when using SMILES as the name.