### PR TITLE
Bugfix: Incorrect blockname used when reading CIF files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2026.1.1 -- Bugfix: Incorrect blockname used when reading CIF files
+    * The blockname, which can be used as the name of the system and/or configuration
+      was incorrect when only some structures where read from a mult-block CIF file.
+
 2025.11.26 -- Added an option for whether to save properties and forces when reading
     * The new option "Save properties" determines whether to save any properties,
       gradients, or velocities in the file to the configuration. If False, only the

--- a/read_structure_step/formats/cif/cif.py
+++ b/read_structure_step/formats/cif/cif.py
@@ -179,6 +179,7 @@ def load_cif(
                         lines = []
                         break
                     if record_no not in indices:
+                        block_name = line[5:].strip()
                         lines = []
                         lines.append(line)
                         continue

--- a/read_structure_step/formats/extxyz/extxyz.py
+++ b/read_structure_step/formats/extxyz/extxyz.py
@@ -187,7 +187,12 @@ def load_extxyz(
                 record_no += 1
                 if record_no > stop:
                     break
-                natoms = int(line)
+                try:
+                    natoms = int(line)
+                except Exception as e:
+                    print(e)
+                    print(f"{line_no}: {line}")
+                    raise
                 section = "header"
                 atom = 0
             elif section == "header":


### PR DESCRIPTION
* The blockname, which can be used as the name of the system and/or configuration was incorrect when only some structures where read from a mult-block CIF file.