### PR TITLE
Bugfix: Fixed error reading multiple structures from .extxyz file

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2026.1.6 -- Bugfix: Fixed error reading multiple structure from .extxyz file
+    * Fixes a crash on reading multiple structures from a .extxyz file when using the
+      system name from the file ("keep current name" or "title") with a given
+      configuration name, like "initial".
+
 2026.1.1 -- Bugfix: Incorrect blockname used when reading CIF files
     * The blockname, which can be used as the name of the system and/or configuration
       was incorrect when only some structures where read from a mult-block CIF file.

--- a/read_structure_step/formats/extxyz/extxyz.py
+++ b/read_structure_step/formats/extxyz/extxyz.py
@@ -277,6 +277,8 @@ def load_extxyz(
                             system = system_db.get_system(sysname)
                         elif structure_no > 1:
                             system = system_db.create_system(name=sysname)
+                            # Must create a configuration!
+                            configuration = system.create_configuration()
                         if configuration_name.lower() in ("keep current name", "title"):
                             names = system.configuration_names
                             if confname in names:


### PR DESCRIPTION
* Fixes a crash on reading multiple structures from a .extxyz file when using the system name from the file ("keep current name" or "title") with a given configuration name, like "initial".