### PR TITLE
Write per-atom charges to extended XYZ

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,12 +1,13 @@
 =======
 History
 =======
-2026.7.13 -- Write per-atom charges to extended XYZ
-    * When writing an extended-XYZ (.extxyz) file, per-atom charges carried by the
-      structure (the standard ``charge`` attribute, e.g. set by the Atomic Charges
-      step) are now written as a ``charge:R:1`` column. This makes it possible to
-      export charges for machine-learning training. No column is written when the
-      structure has no charges.
+2026.7.13 -- Read and write per-atom charges in extended XYZ
+    * Extended-XYZ (.extxyz) files now round-trip per-atom charges. On writing,
+      charges carried by the structure (the standard ``charge`` attribute, e.g.
+      set by the Atomic Charges step) are emitted as a ``charge:R:1`` column, to
+      export charges for machine-learning training; no column is written when the
+      structure has no charges. On reading, a ``charge:R:1`` column is loaded back
+      onto the structure's ``charge`` attribute (when 'save properties' is on).
 
 2026.1.6 -- Bugfix: Fixed error reading multiple structure from .extxyz file
     * Fixes a crash on reading multiple structures from a .extxyz file when using the

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 =======
 History
 =======
+2026.7.13 -- Write per-atom charges to extended XYZ
+    * When writing an extended-XYZ (.extxyz) file, per-atom charges carried by the
+      structure (the standard ``charge`` attribute, e.g. set by the Atomic Charges
+      step) are now written as a ``charge:R:1`` column. This makes it possible to
+      export charges for machine-learning training. No column is written when the
+      structure has no charges.
+
 2026.1.6 -- Bugfix: Fixed error reading multiple structure from .extxyz file
     * Fixes a crash on reading multiple structures from a .extxyz file when using the
       system name from the file ("keep current name" or "title") with a given

--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,12 @@ install: uninstall ## install the package to the active Python's site-packages
 
 uninstall: clean ## uninstall the package
 	pip uninstall --yes $(MODULE)
+
+.PHONY: update
+update: ## post-release: sync main and dev, reinstall, run checks, push dev
+	git checkout main
+	git pull
+	git checkout dev
+	git merge --ff-only main
+	$(MAKE) lint install test
+	git push

--- a/read_structure_step/formats/extxyz/extxyz.py
+++ b/read_structure_step/formats/extxyz/extxyz.py
@@ -561,6 +561,14 @@ def write_extxyz(
                     header += ":velocities:R:3"
                     have_velocities = available[-1]
 
+            # Per-atom charges, if the structure carries them (e.g. set by the
+            # Atomic Charges step). Written as a 'charge:R:1' column, in elementary
+            # charge units. Only the 'charge' Properties column is added here; it
+            # must precede the space-separated attributes (pbc/Lattice/...) below.
+            have_charges = "charge" in configuration.atoms
+            if have_charges:
+                header += ":charge:R:1"
+
             # See if the energy exists as a property. May be "potential energy"
             for prop in (
                 "DfE0*",
@@ -654,7 +662,14 @@ def write_extxyz(
                 factor = Q_(units).m_as("eV^0.5/amu^0.5")
                 velocities = (np.array(velocities) * factor).tolist()
 
-            for symbol, xyz, force, velocity in zip(symbols, xyzs, forces, velocities):
+            if have_charges:
+                charges = list(configuration.atoms["charge"])
+            else:
+                charges = [0.0] * natoms
+
+            for symbol, xyz, force, velocity, charge in zip(
+                symbols, xyzs, forces, velocities, charges
+            ):
                 line = f"{symbol:<2} "
                 line += " ".join([f"{v:14.8f}" for v in xyz])
 
@@ -665,6 +680,9 @@ def write_extxyz(
                 if have_velocities != "no":
                     line += " "
                     line += " ".join([f"{v:14.8f}" for v in velocity])
+
+                if have_charges:
+                    line += f" {charge:14.8f}"
 
                 text.append(line)
             text = "\n".join(text)

--- a/read_structure_step/formats/extxyz/extxyz.py
+++ b/read_structure_step/formats/extxyz/extxyz.py
@@ -340,6 +340,17 @@ def load_extxyz(
                         configuration.atoms.set_velocities(
                             velocities, fractionals=False
                         )
+                    if save_properties and "charge" in data:
+                        # Per-atom charges (a 'charge:R:1' column) go onto the
+                        # structure's standard 'charge' attribute.
+                        atoms = configuration.atoms
+                        if "charge" not in atoms:
+                            atoms.add_attribute(
+                                "charge",
+                                coltype="float",
+                                configuration_dependent=True,
+                            )
+                        atoms["charge"][0:] = data["charge"]
 
                     # Add other properties from the header
                     if save_properties and "energy" in header:

--- a/read_structure_step/read.py
+++ b/read_structure_step/read.py
@@ -81,17 +81,12 @@ def read(
     """
 
     if type(file_name) is not str:
-        raise TypeError(
-            """read_structure_step: The file name must be a string, but a
-            %s was given. """
-            % str(type(file_name))
-        )
+        raise TypeError("""read_structure_step: The file name must be a string, but a
+            %s was given. """ % str(type(file_name)))
 
     if file_name == "":
-        raise NameError(
-            """read_structure_step: The file name for the structure file
-            was not specified."""
-        )
+        raise NameError("""read_structure_step: The file name for the structure file
+            was not specified.""")
 
     file_name = os.path.abspath(file_name)
 

--- a/read_structure_step/write.py
+++ b/read_structure_step/write.py
@@ -56,17 +56,12 @@ def write(
     """
 
     if type(file_name) is not str:
-        raise TypeError(
-            """write_structure_step: The file name must be a string, but a
-            %s was given. """
-            % str(type(file_name))
-        )
+        raise TypeError("""write_structure_step: The file name must be a string, but a
+            %s was given. """ % str(type(file_name)))
 
     if file_name == "":
-        raise NameError(
-            """write_structure_step: The file name for the structure file
-            was not specified."""
-        )
+        raise NameError("""write_structure_step: The file name for the structure file
+            was not specified.""")
 
     file_name = os.path.abspath(file_name)
 

--- a/tests/test_read_structure_step.py
+++ b/tests/test_read_structure_step.py
@@ -77,3 +77,39 @@ def test_write_extxyz_no_charges(tmp_path):
     path = tmp_path / "out.extxyz"
     write_extxyz(str(path), [conf])
     assert "charge:R:1" not in path.read_text()
+
+
+def test_extxyz_charges_round_trip(tmp_path, monkeypatch):
+    """Per-atom charges written to .extxyz are read back onto the structure."""
+    from types import SimpleNamespace
+    import seamm
+    from molsystem.system_db import SystemDB
+    from read_structure_step.formats.extxyz.extxyz import write_extxyz, load_extxyz
+
+    monkeypatch.setattr(seamm, "flowchart_variables", SimpleNamespace(_data={}))
+
+    db = SystemDB(filename="file:rt_test?mode=memory&cache=shared")
+    conf = db.create_system(name="s").create_configuration(name="c")
+    conf.atoms.append(symbol=["H", "H"], x=[0.0, 0.0], y=[0.0, 0.0], z=[0.0, 0.74])
+    conf.atoms.add_attribute("charge", coltype="float", configuration_dependent=True)
+    conf.atoms["charge"][0:] = [-0.13, 0.13]
+
+    path = tmp_path / "rt.extxyz"
+    write_extxyz(str(path), [conf])
+
+    step = SimpleNamespace(
+        parameters=SimpleNamespace(
+            current_values_to_dict=lambda context=None: {"save properties": True}
+        )
+    )
+    conf2 = db.create_system(name="s2").create_configuration(name="c2")
+    load_extxyz(
+        str(path),
+        conf2,
+        system_db=db,
+        system_name=None,
+        configuration_name=None,
+        step=step,
+    )
+    assert "charge" in conf2.atoms
+    assert list(conf2.atoms["charge"]) == pytest.approx([-0.13, 0.13])

--- a/tests/test_read_structure_step.py
+++ b/tests/test_read_structure_step.py
@@ -41,3 +41,39 @@ def test_unregistered_reader(configuration):
     with pytest.raises(KeyError):
         xyz_file = build_filenames.build_data_filename("spc.xyz")
         read_structure_step.read(xyz_file, configuration, extension=".mp3")
+
+
+def test_write_extxyz_charges(tmp_path):
+    """Per-atom charges are written as a 'charge:R:1' column when present."""
+    from molsystem.system_db import SystemDB
+    from read_structure_step.formats.extxyz.extxyz import write_extxyz
+
+    db = SystemDB(filename="file:cq_test?mode=memory&cache=shared")
+    system = db.create_system(name="s")
+    conf = system.create_configuration(name="c")
+    conf.atoms.append(symbol=["H", "H"], x=[0.0, 0.0], y=[0.0, 0.0], z=[0.0, 0.74])
+    conf.atoms.add_attribute("charge", coltype="float", configuration_dependent=True)
+    conf.atoms["charge"][0:] = [-0.13, 0.13]
+
+    path = tmp_path / "out.extxyz"
+    write_extxyz(str(path), [conf])
+    lines = path.read_text().strip().splitlines()
+
+    assert "charge:R:1" in lines[1]  # header Properties column
+    assert lines[2].split()[-1] == f"{-0.13:14.8f}".strip()  # first atom's charge
+    assert lines[3].split()[-1] == f"{0.13:14.8f}".strip()  # second atom's charge
+
+
+def test_write_extxyz_no_charges(tmp_path):
+    """No charge column is written when the structure has no charges."""
+    from molsystem.system_db import SystemDB
+    from read_structure_step.formats.extxyz.extxyz import write_extxyz
+
+    db = SystemDB(filename="file:cq_test2?mode=memory&cache=shared")
+    system = db.create_system(name="s")
+    conf = system.create_configuration(name="c")
+    conf.atoms.append(symbol=["H", "H"], x=[0.0, 0.0], y=[0.0, 0.0], z=[0.0, 0.74])
+
+    path = tmp_path / "out.extxyz"
+    write_extxyz(str(path), [conf])
+    assert "charge:R:1" not in path.read_text()


### PR DESCRIPTION
* When writing an extended-XYZ (`.extxyz`) file, per-atom charges carried by the structure (the standard `charge` attribute — e.g. set by the Atomic Charges step's new "apply to structure" option) are now written as a `charge:R:1` column, in elementary-charge units. This closes the loop for exporting charges for machine-learning training. No column is written when the structure has no charges.

Verified: the column is written only when charges are present, and the reader's dynamic column count means the extra column does not break reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)